### PR TITLE
Pass through original mergeDeep error in cause property

### DIFF
--- a/addon/utils/merge-deep.js
+++ b/addon/utils/merge-deep.js
@@ -195,6 +195,7 @@ export default function mergeDeep(target, source, options = {}) {
       // this is very unlikely to be hit but lets throw an error otherwise
       throw new Error(
         'Unable to `mergeDeep` with your data. Are you trying to merge two ember-data objects? Please file an issue with ember-changeset.',
+        { cause: e },
       );
     }
   }


### PR DESCRIPTION
## Changes proposed in this pull request

This PR passes through the original error with `mergeTargetAndSource` to help with debugging. I'm getting the `mergeDeep` error, but I don't have enough info to debug. I recently noticed that there's a `cause` property that can be used to pass through errors. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause. 