### PR TITLE
add #removeError and #removeErrors to Changeset interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,8 @@ export default class ValidatedForm extends Component {
   - [`validate`](#validate)
   - [`addError`](#adderror)
   - [`pushErrors`](#pusherrors)
+  - [`removeError`](#removeerror)
+  - [`removeErrors`](#removeerrors)
   - [`snapshot`](#snapshot)
   - [`restore`](#restore)
   - [`cast`](#cast)
@@ -891,6 +893,28 @@ changeset.pushErrors('dogYears.age', 'Too short', 'Not a valid number', 'Must be
 ```
 
 This is compatible with `ember-changeset-validations`, and allows you to either add a new error with multiple validation messages or push to an existing array of validation messages.
+
+**[⬆️ back to top](#api)**
+
+#### `removeError`
+
+Manually remove an error from the changeset.
+
+```js
+changeset.removeError('email');
+```
+Removes an error without having to rollback the property.
+
+**[⬆️ back to top](#api)**
+
+#### `removeErrors`
+
+Manually remove an error from the changeset.
+
+```js
+changeset.removeErrors()
+```
+Removes all the errors without having to rollback properties.
 
 **[⬆️ back to top](#api)**
 

--- a/ember-changeset/addon/index.js
+++ b/ember-changeset/addon/index.js
@@ -145,7 +145,6 @@ export class EmberChangeset extends BufferedChangeset {
     super.removeError(key);
 
     notifyPropertyChange(this, key);
-    // Return passed-in `error`.
     return this;
   }
 

--- a/ember-changeset/addon/index.js
+++ b/ember-changeset/addon/index.js
@@ -137,6 +137,29 @@ export class EmberChangeset extends BufferedChangeset {
   }
 
   /**
+   * Manually remove an error from the changeset.
+   *
+   * @method removeError
+   */
+  removeError(key) {
+    super.removeError(key);
+
+    notifyPropertyChange(this, key);
+    // Return passed-in `error`.
+    return this;
+  }
+
+  /**
+   * Manually clears the errors from the changeset
+   *
+   * @method removeError
+   */
+  removeErrors() {
+    super.removeErrors();
+    return this;
+  }
+
+  /**
    * Manually push multiple errors to the changeset as an array.
    *
    * @method pushErrors

--- a/ember-changeset/package.json
+++ b/ember-changeset/package.json
@@ -37,7 +37,7 @@
     "@glimmer/tracking": "^1.1.2",
     "ember-auto-import": "^2.8.1",
     "ember-cli-babel": "^7.26.11",
-    "validated-changeset": "~1.3.4"
+    "validated-changeset": "~1.4.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.25.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^7.26.11
         version: 7.26.11
       validated-changeset:
-        specifier: ~1.3.4
-        version: 1.3.4
+        specifier: ~1.4.0
+        version: 1.4.0
     devDependencies:
       '@babel/eslint-parser':
         specifier: ^7.25.1
@@ -277,8 +277,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       validated-changeset:
-        specifier: ~1.3.4
-        version: 1.3.4
+        specifier: ~1.4.0
+        version: 1.4.0
       webpack:
         specifier: ^5.95.0
         version: 5.96.1
@@ -1485,9 +1485,6 @@ packages:
 
   '@types/symlink-or-copy@1.2.2':
     resolution: {integrity: sha512-MQ1AnmTLOncwEf9IVU+B2e4Hchrku5N67NkgcAHW0p3sdzPe0FNMANxEm6OJUzPniEQGkeT3OROLlCwZJLWFZA==}
-
-  '@types/ungap__structured-clone@0.3.3':
-    resolution: {integrity: sha512-RNmhIPwoip6K/zZOv3ypksTAqaqLEXvlNSXKyrC93xMSOAHZCR7PifW6xKZCwkbbnbM9dwB9X56PPoNTlNwEqw==}
 
   '@ungap/structured-clone@0.3.4':
     resolution: {integrity: sha512-TSVh8CpnwNAsPC5wXcIyh92Bv1gq6E9cNDeeLu7Z4h8V4/qWtXJp7y42qljRkqcpmsve1iozwv1wr+3BNdILCg==}
@@ -3838,10 +3835,6 @@ packages:
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
-  i@0.3.7:
-    resolution: {integrity: sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==}
-    engines: {node: '>=0.4'}
-
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -4782,85 +4775,6 @@ packages:
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
-
-  npm@8.19.4:
-    resolution: {integrity: sha512-3HANl8i9DKnUA89P4KEgVNN28EjSeDCmvEqbzOAuxCFDzdBZzjUl99zgnGpOUumvW5lvJo2HKcjrsc+tfyv1Hw==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    hasBin: true
-    bundledDependencies:
-      - '@isaacs/string-locale-compare'
-      - '@npmcli/arborist'
-      - '@npmcli/ci-detect'
-      - '@npmcli/config'
-      - '@npmcli/fs'
-      - '@npmcli/map-workspaces'
-      - '@npmcli/package-json'
-      - '@npmcli/run-script'
-      - abbrev
-      - archy
-      - cacache
-      - chalk
-      - chownr
-      - cli-columns
-      - cli-table3
-      - columnify
-      - fastest-levenshtein
-      - fs-minipass
-      - glob
-      - graceful-fs
-      - hosted-git-info
-      - ini
-      - init-package-json
-      - is-cidr
-      - json-parse-even-better-errors
-      - libnpmaccess
-      - libnpmdiff
-      - libnpmexec
-      - libnpmfund
-      - libnpmhook
-      - libnpmorg
-      - libnpmpack
-      - libnpmpublish
-      - libnpmsearch
-      - libnpmteam
-      - libnpmversion
-      - make-fetch-happen
-      - minimatch
-      - minipass
-      - minipass-pipeline
-      - mkdirp
-      - mkdirp-infer-owner
-      - ms
-      - node-gyp
-      - nopt
-      - npm-audit-report
-      - npm-install-checks
-      - npm-package-arg
-      - npm-pick-manifest
-      - npm-profile
-      - npm-registry-fetch
-      - npm-user-validate
-      - npmlog
-      - opener
-      - p-map
-      - pacote
-      - parse-conflict-json
-      - proc-log
-      - qrcode-terminal
-      - read
-      - read-package-json
-      - read-package-json-fast
-      - readdir-scoped-modules
-      - rimraf
-      - semver
-      - ssri
-      - tar
-      - text-table
-      - tiny-relative-date
-      - treeverse
-      - validate-npm-package-name
-      - which
-      - write-file-atomic
 
   npmlog@6.0.2:
     resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
@@ -6320,8 +6234,8 @@ packages:
   validate-peer-dependencies@1.2.0:
     resolution: {integrity: sha512-nd2HUpKc6RWblPZQ2GDuI65sxJ2n/UqZwSBVtj64xlWjMx0m7ZB2m9b2JS3v1f+n9VWH/dd1CMhkHfP6pIdckA==}
 
-  validated-changeset@1.3.4:
-    resolution: {integrity: sha512-kodJCCnd3oA7sCtUkkl7olhB1MQUz2uTAYUnE38R4Dn8hIU4bZVWass8KPGt0fvu2WdkjFJOGpXDrT0isqNKqw==}
+  validated-changeset@1.4.0:
+    resolution: {integrity: sha512-4LaQnVjaOCXDAIm/RYqd/RA94lHa7uCEjBcm+puTZkRmvTCqRkLh3dYSQ10DH/a7JY0HOj0rop0TXx9pbBqZuw==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -8172,8 +8086,6 @@ snapshots:
       '@types/send': 0.17.4
 
   '@types/symlink-or-copy@1.2.2': {}
-
-  '@types/ungap__structured-clone@0.3.3': {}
 
   '@ungap/structured-clone@0.3.4': {}
 
@@ -11505,8 +11417,6 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  i@0.3.7: {}
-
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -12438,8 +12348,6 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
-
-  npm@8.19.4: {}
 
   npmlog@6.0.2:
     dependencies:
@@ -14083,12 +13991,9 @@ snapshots:
       resolve-package-path: 3.1.0
       semver: 7.6.3
 
-  validated-changeset@1.3.4:
+  validated-changeset@1.4.0:
     dependencies:
-      '@types/ungap__structured-clone': 0.3.3
       '@ungap/structured-clone': 0.3.4
-      i: 0.3.7
-      npm: 8.19.4
 
   vary@1.1.2: {}
 

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -71,7 +71,7 @@
     "stylelint-config-standard": "^34.0.0",
     "stylelint-prettier": "^4.1.0",
     "tracked-built-ins": "^3.3.0",
-    "validated-changeset": "~1.3.4",
+    "validated-changeset": "~1.4.0",
     "webpack": "^5.95.0",
     "yup": "^0.32.11"
   },

--- a/test-app/tests/unit/changeset-test.js
+++ b/test-app/tests/unit/changeset-test.js
@@ -3100,6 +3100,94 @@ module('Unit | Utility | changeset', function (hooks) {
   });
 
   /**
+   * #removeError
+   */
+
+  test('#removeError removes an error from the changeset', async function (assert) {
+    let dummyChangeset = Changeset(dummyModel);
+    dummyChangeset.addError('email', {
+      value: 'jim@bob.com',
+      validation: 'Email already taken',
+    });
+
+    assert.true(dummyChangeset.isInvalid);
+    assert.strictEqual(get(dummyChangeset, 'error.email.validation'), 'Email already taken');
+
+    dummyChangeset.removeError('email');
+    assert.true(dummyChangeset.isValid);
+
+    assert.strictEqual(get(dummyChangeset, 'error.email.validation'), undefined);
+  });
+
+  test('#removeError using an invalid key does not throw an error', async function (assert) {
+    let dummyChangeset = Changeset(dummyModel);
+    dummyChangeset.addError('email', {
+      value: 'jim@bob.com',
+      validation: 'Email already taken',
+    });
+
+    assert.true(dummyChangeset.isInvalid);
+    assert.strictEqual(get(dummyChangeset, 'error.email.validation'), 'Email already taken');
+
+    dummyChangeset.removeError('email');
+    dummyChangeset.removeError('foo');
+    assert.true(dummyChangeset.isValid);
+
+    assert.strictEqual(get(dummyChangeset, 'error.email.validation'), undefined);
+  });
+
+  test('#removeError removing one error leaves the other', async function (assert) {
+    let dummyChangeset = Changeset(dummyModel);
+    dummyChangeset.addError('email', {
+      value: 'jim@bob.com',
+      validation: 'Email already taken',
+    });
+    dummyChangeset.addError('age', {
+      value: '0',
+      validation: 'Age is too low',
+    });
+
+    assert.true(dummyChangeset.isInvalid);
+    assert.strictEqual(get(dummyChangeset, 'error.email.validation'), 'Email already taken');
+    assert.strictEqual(get(dummyChangeset, 'error.age.validation'), 'Age is too low');
+
+    dummyChangeset.removeError('email');
+    assert.false(dummyChangeset.isValid);
+
+    assert.strictEqual(get(dummyChangeset, 'error.email.validation'), undefined);
+    assert.strictEqual(get(dummyChangeset, 'error.age.validation'), 'Age is too low');
+  });
+
+  /**
+   * #removeErrors
+   */
+
+  test('#removeErrors removes all errors', async function (assert) {
+    let dummyChangeset = Changeset(dummyModel);
+    dummyChangeset.addError('email', {
+      value: 'jim@bob.com',
+      validation: 'Email already taken',
+    });
+
+    assert.true(dummyChangeset.isInvalid);
+    assert.strictEqual(get(dummyChangeset, 'error.email.validation'), 'Email already taken');
+
+    dummyChangeset.removeErrors();
+    assert.true(dummyChangeset.isValid);
+
+    assert.strictEqual(get(dummyChangeset, 'error.email.validation'), undefined);
+    assert.propEqual(get(dummyChangeset, 'errors'), []);
+  });
+
+  test('#removeErrors succeeds even when there are no errors', async function (assert) {
+    let dummyChangeset = Changeset(dummyModel);
+    assert.false(dummyChangeset.isInvalid);
+    dummyChangeset.removeErrors();
+    assert.true(dummyChangeset.isValid);
+    assert.propEqual(get(dummyChangeset, 'errors'), []);
+  });
+
+  /**
    * #pushErrors
    */
 

--- a/test-app/tests/unit/changeset-test.js
+++ b/test-app/tests/unit/changeset-test.js
@@ -3111,12 +3111,18 @@ module('Unit | Utility | changeset', function (hooks) {
     });
 
     assert.true(dummyChangeset.isInvalid);
-    assert.strictEqual(get(dummyChangeset, 'error.email.validation'), 'Email already taken');
+    assert.strictEqual(
+      get(dummyChangeset, 'error.email.validation'),
+      'Email already taken',
+    );
 
     dummyChangeset.removeError('email');
     assert.true(dummyChangeset.isValid);
 
-    assert.strictEqual(get(dummyChangeset, 'error.email.validation'), undefined);
+    assert.strictEqual(
+      get(dummyChangeset, 'error.email.validation'),
+      undefined,
+    );
   });
 
   test('#removeError using an invalid key does not throw an error', async function (assert) {
@@ -3127,13 +3133,19 @@ module('Unit | Utility | changeset', function (hooks) {
     });
 
     assert.true(dummyChangeset.isInvalid);
-    assert.strictEqual(get(dummyChangeset, 'error.email.validation'), 'Email already taken');
+    assert.strictEqual(
+      get(dummyChangeset, 'error.email.validation'),
+      'Email already taken',
+    );
 
     dummyChangeset.removeError('email');
     dummyChangeset.removeError('foo');
     assert.true(dummyChangeset.isValid);
 
-    assert.strictEqual(get(dummyChangeset, 'error.email.validation'), undefined);
+    assert.strictEqual(
+      get(dummyChangeset, 'error.email.validation'),
+      undefined,
+    );
   });
 
   test('#removeError removing one error leaves the other', async function (assert) {
@@ -3148,14 +3160,26 @@ module('Unit | Utility | changeset', function (hooks) {
     });
 
     assert.true(dummyChangeset.isInvalid);
-    assert.strictEqual(get(dummyChangeset, 'error.email.validation'), 'Email already taken');
-    assert.strictEqual(get(dummyChangeset, 'error.age.validation'), 'Age is too low');
+    assert.strictEqual(
+      get(dummyChangeset, 'error.email.validation'),
+      'Email already taken',
+    );
+    assert.strictEqual(
+      get(dummyChangeset, 'error.age.validation'),
+      'Age is too low',
+    );
 
     dummyChangeset.removeError('email');
     assert.false(dummyChangeset.isValid);
 
-    assert.strictEqual(get(dummyChangeset, 'error.email.validation'), undefined);
-    assert.strictEqual(get(dummyChangeset, 'error.age.validation'), 'Age is too low');
+    assert.strictEqual(
+      get(dummyChangeset, 'error.email.validation'),
+      undefined,
+    );
+    assert.strictEqual(
+      get(dummyChangeset, 'error.age.validation'),
+      'Age is too low',
+    );
   });
 
   /**
@@ -3170,12 +3194,18 @@ module('Unit | Utility | changeset', function (hooks) {
     });
 
     assert.true(dummyChangeset.isInvalid);
-    assert.strictEqual(get(dummyChangeset, 'error.email.validation'), 'Email already taken');
+    assert.strictEqual(
+      get(dummyChangeset, 'error.email.validation'),
+      'Email already taken',
+    );
 
     dummyChangeset.removeErrors();
     assert.true(dummyChangeset.isValid);
 
-    assert.strictEqual(get(dummyChangeset, 'error.email.validation'), undefined);
+    assert.strictEqual(
+      get(dummyChangeset, 'error.email.validation'),
+      undefined,
+    );
     assert.propEqual(get(dummyChangeset, 'errors'), []);
   });
 

--- a/test-app/tests/unit/changeset-test.js
+++ b/test-app/tests/unit/changeset-test.js
@@ -3103,6 +3103,33 @@ module('Unit | Utility | changeset', function (hooks) {
    * #removeError
    */
 
+  test('#removeError does not reset field values', async function (assert) {
+    let dummyChangeset = Changeset(dummyModel);
+
+    assert.strictEqual(dummyChangeset.email, undefined);
+
+    dummyModel.setProperties({
+      email: 'test@example.com',
+      name: 'Jim Bob',
+    });
+
+    dummyChangeset.addError('email', {
+      value: 'test@example.com',
+      validation: 'Email already taken',
+    });
+
+    assert.true(dummyChangeset.isInvalid);
+    assert.strictEqual(
+      get(dummyChangeset, 'error.email.validation'),
+      'Email already taken',
+    );
+
+    dummyChangeset.removeError('email');
+    assert.true(dummyChangeset.isValid);
+    assert.strictEqual(dummyChangeset.email, 'test@example.com');
+    assert.strictEqual(dummyChangeset.name, 'Jim Bob');
+  });
+
   test('#removeError removes an error from the changeset', async function (assert) {
     let dummyChangeset = Changeset(dummyModel);
     dummyChangeset.addError('email', {
@@ -3193,10 +3220,19 @@ module('Unit | Utility | changeset', function (hooks) {
       validation: 'Email already taken',
     });
 
+    dummyChangeset.addError('age', {
+      value: '0',
+      validation: 'Age is too low',
+    });
+
     assert.true(dummyChangeset.isInvalid);
     assert.strictEqual(
       get(dummyChangeset, 'error.email.validation'),
       'Email already taken',
+    );
+    assert.strictEqual(
+      get(dummyChangeset, 'error.age.validation'),
+      'Age is too low',
     );
 
     dummyChangeset.removeErrors();
@@ -3206,6 +3242,8 @@ module('Unit | Utility | changeset', function (hooks) {
       get(dummyChangeset, 'error.email.validation'),
       undefined,
     );
+
+    assert.strictEqual(get(dummyChangeset, 'error.age.validation'), undefined);
     assert.propEqual(get(dummyChangeset, 'errors'), []);
   });
 


### PR DESCRIPTION
I'm using ember-changeset with ember-changeset-validations with some validations where the presence requirement of one field is dependent on the value of another. If the dependent field ends up with an error and then the field it depends on changes, the error should really be cleared. But it didn't seem like there was a clean way to do that without actually rolling back the property. This seems to have come up a number of times in issues and PRs.

> This seems to be something that works in the newer `validated-changeset` 4.x-5.x experiment, but is not something available in the classic BufferedChangeset. 

> https://github.com/poteto/ember-changeset/issues/361
> https://github.com/poteto/ember-changeset/issues/282

> There were some workarounds in the above threads, like effectively "clearing" an error by changeset.addError('email', null), but in my testing it still left the changeset with an isValid = false state.

This PR adds removeError and removeErrors to the Changeset interface, which was just added to validated-changeset 1.4.0