### PR TITLE
Drop support for Ember.js versions below 4.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,6 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-3.20
-          - ember-lts-3.24
-          - ember-lts-3.28
-          - ember-lts-4.4
           - ember-lts-4.8
           - ember-lts-4.12
           - ember-lts-5.4

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Compatibility
 
-- Ember.js v3.20 or above
+- Ember.js v4.8 or above
 - Ember CLI v3.20 or above
 - Node.js v18 or above
 

--- a/ember-changeset/package.json
+++ b/ember-changeset/package.json
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "ember-data": "*",
-    "ember-source": ">=3.20.0"
+    "ember-source": ">= 4.8.0"
   },
   "peerDependenciesMeta": {
     "ember-data": {

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -22,57 +22,6 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
-        name: 'ember-lts-3.20',
-        npm: {
-          devDependencies: {
-            '@ember/test-helpers': '^2.9.3',
-            'ember-cli': '~4.12.3',
-            'ember-cli-app-version': '^5.0.0',
-            'ember-data': '~3.20.0',
-            'ember-qunit': '^5.1.5',
-            'ember-resolver': '^8.0.0',
-            'ember-source': '~3.20.5',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.24',
-        npm: {
-          devDependencies: {
-            '@ember/test-helpers': '^2.9.3',
-            'ember-cli': '~4.12.3',
-            'ember-cli-app-version': '^5.0.0',
-            'ember-data': '~3.24.0',
-            'ember-qunit': '^5.1.5',
-            'ember-resolver': '^8.0.0',
-            'ember-source': '~3.24.3',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.28',
-        npm: {
-          devDependencies: {
-            '@ember/test-helpers': '^2.9.3',
-            'ember-cli': '~4.12.3',
-            'ember-data': '~3.28.0',
-            'ember-qunit': '^6.2.0',
-            'ember-resolver': '^8.0.0',
-            'ember-source': '~3.28.4',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-4.4',
-        npm: {
-          devDependencies: {
-            'ember-data': '~4.4.0',
-            'ember-resolver': '^8.0.0',
-            'ember-source': '~4.4.0',
-          },
-        },
-      },
-      {
         name: 'ember-lts-4.8',
         npm: {
           devDependencies: {


### PR DESCRIPTION
This simplifies CI setup and support for Embroider/Vite moving forward.

Currently Ember.js v6.3 is the latest version, so it's still two old major versions.

As addon is pretty simple, there is high chance it would work even with older versions if needed.